### PR TITLE
Fix Pod Term Detection and Make SkipLevels Configurable

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -12,22 +12,25 @@ func TestSkipEvent(t *testing.T) {
 	t.Parallel()
 
 	evt := &v1.Event{Type: v1.EventTypeNormal}
-	if !skipEvent(evt) {
+
+	skipLevels := []string{"normal"}
+
+	if !skipEvent(evt, skipLevels) {
 		t.Error("Normal events must be skipped")
 	}
 
 	evt.Type = v1.EventTypeWarning
-	if skipEvent(evt) {
+	if skipEvent(evt, skipLevels) {
 		t.Error("Warnings events must not be skipped")
 	}
 
 	evt.Type = "Error"
-	if skipEvent(evt) {
+	if skipEvent(evt, skipLevels) {
 		t.Error("Error events must not be skipped")
 	}
 
 	evt.Type = "Unknown"
-	if skipEvent(evt) {
+	if skipEvent(evt, skipLevels) {
 		t.Error("Unknown event types must not be skipped")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -62,9 +62,19 @@ func main() {
 		log.Fatalf("Error creating kubernetes client: %v", err)
 	}
 
+	skipEnv, isSet := os.LookupEnv("SKIP_EVENT_LEVELS")
+	var skipLevels []string
+
+	if isSet {
+		skipLevels = strings.Split(strings.ToLower(skipEnv), ",")
+	} else {
+		skipLevels = []string{strings.ToLower(v1.EventTypeNormal)}
+	}
+
 	app := application{
 		clientset:          clientset,
 		defaultEnvironment: os.Getenv("SENTRY_ENVIRONMENT"),
+		skipEventLevels:    skipLevels,
 	}
 
 	namespace := os.Getenv("NAMESPACE")

--- a/test_pod.yaml
+++ b/test_pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+  namespace: default
+spec:
+  containers:
+    - command:
+        - "/bin/sh"
+      args:
+        - "-c"
+        - "sleep 3; exit 123"
+      image: alpine
+      imagePullPolicy: IfNotPresent
+      name: test
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  hostNetwork: true
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 1


### PR DESCRIPTION
Hi @janLo,

regarding your question about the code path being taken I think the implementation was indeed not quite correct. LastTerminationState is the previous state, not the current one. It is set only in cases of restarting containers.

The doc is not very good on that though:
https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#containerstatus-v1-core
See `state` vs `lastState`

I also added the feature to configure the skipped event levels.

The change does work properly against my local Sentry 9.1.2 desktop setup.
